### PR TITLE
Github: allow :runner:

### DIFF
--- a/harold/plugins/github.py
+++ b/harold/plugins/github.py
@@ -223,7 +223,8 @@ class SalonDatabase(object):
         state = "unreviewed"
         if is_author and ":haircut:" in body:
             state = "haircut"
-        elif ":running:" in body:
+        elif (":running:" in body or
+              ":runner:" in body):
             state = "running"
         elif ":nail_care:" in body:
             state = "nail_care"


### PR DESCRIPTION
I frequently use `:runner:` instead of `:running:` because it's the one that
pops up in Github's autocomplete.  Since they're the same emoji, it'd be nice
to support both.

(I didn't test this at all.)

:eyeglasses: @spladug 