### PR TITLE
Don't restart the :shell: expiration timer after a yes

### DIFF
--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -281,7 +281,7 @@ class DeployMonitor(object):
             self.irc.bot.send_message(self.config.channel, "sorry, but @%s has to say it!" % self.queue[0])
             return
 
-        self._start_conch_expiration()
+        self._cancel_conch_expiration()
         self.irc.bot.send_message(self.config.channel, "OK, understood. :disappear:")
 
     def release(self, irc, sender, channel, *ignored):


### PR DESCRIPTION
:eyeglasses: @spladug

> If a yes is given mid-deploy, then the timer would start again. Also if
> there's a major bug being fixed, then having to say yes every 5
> minutes might be a little much.