### PR TITLE
Add support for per-salon deploy hours.

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -84,6 +84,8 @@ organizations = reddit
 default_hours_start = 0900
 default_hours_end = 1700
 default_tz = America/Los_Angeles
+blackout_hours_start = 1700
+blackout_hours_end = 2359
 
 
 ; A github webhook listener that announces commits, pull requests, and code

--- a/example.ini
+++ b/example.ini
@@ -81,6 +81,9 @@ connection_string = sqlite:////home/ubuntu/src/harold/test.db
 [harold:plugin:deploy]
 ; which github users/organizations repos can be added from
 organizations = reddit
+default_hours_start = 0900
+default_hours_end = 1700
+default_tz = America/Los_Angeles
 
 
 ; A github webhook listener that announces commits, pull requests, and code

--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -277,7 +277,7 @@ class Salon(object):
         self.update_topic(irc)
 
     def current_time_status(self):
-        date = datetime.date.today()
+        date = datetime.date.today(tz=self.tz)
         time = datetime.datetime.now(tz=self.tz).time()
 
         start = self.deploy_hours_start

--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -453,6 +453,8 @@ class DeployMonitor(object):
 
         blackout_tz = self.config.default_tz
         blackout_date = datetime.datetime.now(tz=blackout_tz).date()
+        blackout_start = blackout_tz.localize(datetime.datetime.combine(blackout_date, self.config.blackout_hours_start))
+        blackout_end = blackout_tz.localize(datetime.datetime.combine(blackout_date, self.config.blackout_hours_end))
 
         # User-defined deploy hours can only exist in a single day in their
         # given timezone, but may cross day boundaries in the blackout
@@ -461,8 +463,6 @@ class DeployMonitor(object):
         # Example: Deploy hours of 0100-0200 EST, blackout hours of 2200-2300 PST.
         for i in (0, 1):
             delta = datetime.timedelta(days=i)
-            blackout_start = blackout_tz.localize(datetime.datetime.combine(blackout_date, self.config.blackout_hours_start))
-            blackout_end = blackout_tz.localize(datetime.datetime.combine(blackout_date, self.config.blackout_hours_end))
             blackout_timerange = (blackout_start - delta, blackout_end - delta)
 
             if timerange_overlap(deploy_timerange, blackout_timerange):

--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -33,9 +33,9 @@ DEPLOY_TTL = 3600
 
 class DeployConfig(PluginConfig):
     organizations = Option(tup)
-    default_hours_start = Option(str)
-    default_hours_end = Option(str)
-    default_tz = Option(str)
+    default_hours_start = Option(parse_time)
+    default_hours_end = Option(parse_time)
+    default_tz = Option(pytz.timezone)
 
 
 class DeployListener(ProtectedResource):
@@ -388,10 +388,13 @@ class DeployMonitor(object):
             irc.send_message(channel, "That doesn't look like a valid emoji.")
             return
 
-        deploy_hours_start = parse_time(self.config.default_hours_start)
-        deploy_hours_end = parse_time(self.config.default_hours_end)
-        tz = pytz.timezone(self.config.default_tz)
-        new_salon = yield self.salons.create(channel, emoji, deploy_hours_start, deploy_hours_end, tz)
+        new_salon = yield self.salons.create(
+            channel,
+            emoji,
+            self.config.default_hours_start,
+            self.config.default_hours_end,
+            self.config.default_tz
+        )
         new_salon.update_topic(irc, force=True)
 
     @inlineCallbacks

--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -276,8 +276,9 @@ class Salon(object):
         self.update_topic(irc)
 
     def current_time_status(self):
-        date = datetime.date.today(tz=self.tz)
-        time = datetime.datetime.now(tz=self.tz).time()
+        now = datetime.datetime.now(tz=self.tz)
+        date = now.date()
+        time = now.time()
 
         end_datetime = datetime.datetime.combine(date, self.deploy_hours_end)
         cleanup = (end_datetime - datetime.timedelta(hours=1)).time()

--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -280,19 +280,17 @@ class Salon(object):
         date = datetime.date.today(tz=self.tz)
         time = datetime.datetime.now(tz=self.tz).time()
 
-        start = self.deploy_hours_start
-        end = self.deploy_hours_end
         end_datetime = datetime.datetime.combine(date, self.deploy_hours_end)
         cleanup = (end_datetime - datetime.timedelta(hours=1)).time()
 
-        if time < start:
+        if time < self.deploy_hours_start:
             return "after_hours"
 
         if date.weekday() in (0, 1, 2, 3):
             # monday through thursday, 1 hour before end
             if time < cleanup:
                 return "work_time"
-            elif time < end:
+            elif time < self.deploy_hours_end:
                 return "cleanup_time"
             else:
                 return "after_hours"

--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -180,7 +180,6 @@ class Salon(object):
             status = ":no_entry_sign: deploys ON HOLD (%s)" % self.current_hold
         else:
             time_status = self.current_time_status()
-            print time_status
 
             if time_status == "work_time":
                 status = ":office: working hours, normal deploy rules apply"

--- a/harold/utils.py
+++ b/harold/utils.py
@@ -84,3 +84,14 @@ def utc_offset(tz):
     for the current time.
     """
     return datetime.datetime.now(tz=tz).strftime("%z")
+
+# Takes in two tuples of (datetime.time, datetime.time) representing a time
+# range, and returns true if those ranges overlap.
+def timerange_overlap(rangeA, rangeB):
+    print rangeA
+    print rangeB
+    max_start = max(rangeA[0], rangeB[0])
+    min_end = min(rangeA[1], rangeB[1])
+
+    print max_start, min_end
+    return max_start < min_end

--- a/harold/utils.py
+++ b/harold/utils.py
@@ -1,3 +1,6 @@
+import datetime
+
+
 def pretty_time_span(delta):
     seconds = int(delta.total_seconds())
     minutes, seconds = divmod(seconds, 60)
@@ -65,3 +68,19 @@ def constant_time_compare(actual, expected):
         for i in xrange(actual_len):
             result |= ord(actual[i]) ^ ord(expected[i % expected_len])
     return result == 0
+
+
+def fmt_time(time):
+    return time.strftime("%H%M")
+
+
+def parse_time(time_str):
+    return datetime.datetime.strptime(time_str, "%H%M").time()
+
+
+def utc_offset(tz):
+    """
+    Takes a timezone and returns UTC offset (e.g. -0700) of that timezone,
+    for the current time.
+    """
+    return datetime.datetime.now(tz=tz).strftime("%z")

--- a/harold/utils.py
+++ b/harold/utils.py
@@ -88,8 +88,6 @@ def utc_offset(tz):
 # Takes in two tuples of (datetime.time, datetime.time) representing a time
 # range, and returns true if those ranges overlap.
 def timerange_overlap(rangeA, rangeB):
-    print rangeA
-    print rangeB
     max_start = max(rangeA[0], rangeB[0])
     min_end = min(rangeA[1], rangeB[1])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,4 @@ txaio==2.9.0
 urllib3==1.24.2
 Werkzeug==0.14.1
 zope.interface==4.4.3
+pytz>=2018.9


### PR DESCRIPTION
This adds two new commands to harold: `set_deploy_hours` and
`get_deploy_hours`.

`set_deploy_hours` allows sallons to have their deploy hours set to a
specific time range and timezone. This is stored in the database, and
all previous hard-coded deploy hours checks will use these times.

`get_deploy_hours` prints whatever the current deploy hours are.

The deploy hours are pegged to a specific timezone, per salon. Harold
will honour whatever DST applies to the provided time zone.

This code assumes that deploy hours of a salon will never cross the day
boundary in the given timezone.

:eyeglasses: @spladug @rram 

One thing I'm unsure how to handle cleanly: Salons which won't have these columns populated in the database. The context of the default deploy hours as-is belongs to the `deploy` plugin, but I'd need that info in the `salons` plugin. Any suggestions on how I might solve this?