### PR TITLE
Add support for hold/unhold via HTTP plugin

### DIFF
--- a/salon/models.py
+++ b/salon/models.py
@@ -111,6 +111,9 @@ class Salon(db.Model):
 
     name = db.Column(db.String, primary_key=True, nullable=False)
     conch_emoji = db.Column(db.String, nullable=False)
+    deploy_hours_start = db.Column(db.String, default=True)
+    deploy_hours_end = db.Column(db.String, default=True)
+    tz = db.Column(db.String, default=True)
     allow_deploys = db.Column(db.Boolean, default=True)
 
 


### PR DESCRIPTION
Harold HTTP clients can now trigger a hold or unhold on
all salons by issuing the correct commands.

Adding a deploy hold type enum class and support for
distinguising between a code freeze and a manually
triggered deploy hold.