### PR TITLE
Fix get_salon_names request bug

### DIFF
--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -217,13 +217,19 @@ class DeployGetSalonNamesListener(DeployListener):
     isLeaf = True
 
     def _handle_request(self, request):
-        salons = yield self.salons.all()
-        salon_names = [salon.name for salon in salons]
 
-        # Configure the response
-        request.setHeader("Content-Type", "application/json")
-        request.write(json.dumps(salon_names))
-        request.finish()
+        def send_response(salons):
+            salon_names = [salon.name for salon in salons]
+
+            # Configure the response
+            request.setHeader("Content-Type", "application/json")
+            request.write(json.dumps(salon_names))
+            request.finish()
+
+        salons_deferred = self.monitor.salons.all()
+        salons_deferred.addCallback(send_response)
+
+        return server.NOT_DONE_YET
 
 
 class DeploySendAnnouncementListener(DeployListener):

--- a/harold/plugins/http.py
+++ b/harold/plugins/http.py
@@ -46,14 +46,15 @@ class ProtectedResource(resource.Resource):
             raise AuthenticationError
 
     def render_GET(self, request):
+        response = ""
         try:
             self._authenticate_request(request)
         except AuthenticationError:
             request.setResponseCode(403)
         else:
-            self._handle_request(request)
+            response = self._handle_request(request)
 
-        return ""
+        return response
 
     def render_POST(self, request):
         try:

--- a/harold/plugins/http.py
+++ b/harold/plugins/http.py
@@ -46,7 +46,6 @@ class ProtectedResource(resource.Resource):
             raise AuthenticationError
 
     def render_GET(self, request):
-        response = ""
         try:
             self._authenticate_request(request)
         except AuthenticationError:
@@ -54,7 +53,7 @@ class ProtectedResource(resource.Resource):
         else:
             response = self._handle_request(request)
 
-        return response
+        return response or ""
 
     def render_POST(self, request):
         try:


### PR DESCRIPTION
Made it so that this uses the Twisted deferred request and handles
the call back properly.  Now, the list of salon names will be
returned as a JSON array in the response boody.