### PR TITLE
Allow for POST requests to return a response

### DIFF
--- a/harold/plugins/http.py
+++ b/harold/plugins/http.py
@@ -61,9 +61,9 @@ class ProtectedResource(resource.Resource):
         except AuthenticationError:
             request.setResponseCode(403)
         else:
-            self._handle_request(request)
+            response = self._handle_request(request)
 
-        return ""
+        return response or ""
 
 
 def make_plugin(config):


### PR DESCRIPTION
This change is mainly to solve the Google Apps script
HTTP client issue wherby you cannot send a GET request
with a body.  So this will allow endpoints like
/harold/deploy/get_salon_names to be able to be a POST
request endpoint so that it can have a body.  We need
the request to have a body because the body data is what
is signed by the HTTP client making the request.