### PR TITLE
Fix bugs for setting/removing deploy holds

### DIFF
--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -745,7 +745,8 @@ class DeployMonitor(object):
             return
 
         type = DeployHoldType.manual
-        if 'freeze' in reason[0].lower():
+        # 'reason' is the reason string broken down as a tuple of words
+        if 'freeze' in ' '.join(reason).lower():
             type = DeployHoldType.code_freeze
 
         salon.hold(irc, type, reason)
@@ -755,7 +756,8 @@ class DeployMonitor(object):
         salons = yield self.salons.all()
 
         type = DeployHoldType.manual
-        if 'freeze' in reason[0].lower():
+        # 'reason' is the reason string broken down as a tuple of words
+        if 'freeze' in ' '.join(reason).lower():
             type = DeployHoldType.code_freeze
 
         for salon in salons:


### PR DESCRIPTION
Fix bugs for setting/removing deploy holds
    
    1. Fix for setting a hold
    
    The value of the 'reason' input param for the 'hold' and 'hold_all'
    method of the DeployMonitor class is a tuple and not a string.
    The reason text is the first member of the tuple.

    Fix for this issue: 
https://reddit.slack.com/archives/C752635JN/p1569953685355300thread_ts=1569952646.350100&cid=C752635JN
    
    2. Fix hold/unhold HTTP request bug
    
    The the code before this commit, we were incorrectly
    trying to make a call to fetch a salon by calling a function
    that returns the data in an asynchronous manner.  The reason
    for this is that before we were trying to fetch the salon
    and do some verification and return an error to the HTTP
    client if the salon could not be found.  This caused a bug
    when trying to set/remove a deploy hold using the HTTP endpoints.
    
    With this fix, we simple blindly make the call to hold/unhold.
    If the salon cannot be found the call simply does nothing.  This
    is simpler even though any error is not communicated to the
    client.
    
    3. Update comment

