### PR TITLE
Cleanup the Hold/Unhold HTTP APIs for consistency

### DIFF
--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -170,8 +170,9 @@ class DeployHoldListener(DeployListener):
 
     def _handle_request(self, request):
         reason = request.args['reason'][0]
-        salon_name = request.args['salon_name'][0]
-        self.monitor.hold(self.monitor.irc, None, salon_name, reason)
+        salon_name = request.args['salon'][0]
+        channel = '#' + salon_name
+        self.monitor.hold(self.monitor.irc, None, channel, reason)
 
 
 class DeployUnHoldListener(DeployListener):
@@ -181,8 +182,9 @@ class DeployUnHoldListener(DeployListener):
     isLeaf = True
 
     def _handle_request(self, request):
-        salon_name = request.args['salon_name'][0]
-        self.monitor.unhold(self.monitor.irc, None, salon_name)
+        salon_name = request.args['salon'][0]
+        channel = '#' + salon_name
+        self.monitor.unhold(self.monitor.irc, None, channel)
 
 
 class DeployHoldAllListener(DeployListener):


### PR DESCRIPTION
Before this change, the Hold/Unhold HTTP APIs expect a
form paramter with the key as 'salon_name' and the value
must be a slack channel name (prepended with the '#') character.
This forces the client to be aware of the fact that there is
some integration between salons and slack channels.  Moreover
the naming of the form args is confusing (the key is a
salon name but the actual value is a slack channel).

While the existing code still works, it is a bit inconsistent
with other HTTP APIs and also creates some confusion.  The
/harold/deploy/get_salon_names endpoint returns a list of
salon names (and not slack channel names).  Other endpoints
simply expect the salon name.

So this PR removes the confusion - only the salon name is
expected.  Moreover, the form arg key is now named 'salon'
to be consistent with the other Harold HTTP APIs.