### PR TITLE
Fix for hold/unhold/hold_all/unhold_all issue

### DIFF
--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -171,7 +171,7 @@ class DeployHoldListener(DeployListener):
     def _handle_request(self, request):
         reason = request.args['reason'][0]
         salon_name = request.args['salon_name'][0]
-        self.monitor.hold(self.monitor.irc, None, salon_name, reason)
+        self.monitor.hold(self.monitor.irc.bot, None, salon_name, reason)
 
 
 class DeployUnHoldListener(DeployListener):
@@ -182,7 +182,7 @@ class DeployUnHoldListener(DeployListener):
 
     def _handle_request(self, request):
         salon_name = request.args['salon_name'][0]
-        self.monitor.unhold(self.monitor.irc, None, salon_name)
+        self.monitor.unhold(self.monitor.irc.bot, None, salon_name)
 
 
 class DeployHoldAllListener(DeployListener):
@@ -193,7 +193,7 @@ class DeployHoldAllListener(DeployListener):
 
     def _handle_request(self, request):
         reason = request.args['reason'][0]
-        self.monitor.hold_all(self.monitor.irc, None, None, reason)
+        self.monitor.hold_all(self.monitor.irc.bot, None, None, reason)
 
 
 class DeployUnholdAllListener(DeployListener):
@@ -203,7 +203,7 @@ class DeployUnholdAllListener(DeployListener):
     isLeaf = True
 
     def _handle_request(self, request):
-        self.monitor.unhold_all(self.monitor.irc, None, None)
+        self.monitor.unhold_all(self.monitor.irc.bot, None, None)
 
 
 class DeployGetSalonNamesListener(DeployListener):


### PR DESCRIPTION
The existing code was not passing down the correct
Plugin object so we ended up with an unhandled
exception when trying to call the 'set_topic'
method.

Fix for the following unhandled exception:
```
2019-10-05 00:38:57+0000 [-] Unhandled error in Deferred:
2019-10-05 00:38:57+0000 [-] Unhandled Error
	Traceback (most recent call last):
	  File "/home/ubuntu/venv/harold/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 393, in callback
	    self._startRunCallbacks(result)
	  File "/home/ubuntu/venv/harold/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 501, in _startRunCallbacks
	    self._runCallbacks()
	  File "/home/ubuntu/venv/harold/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 588, in _runCallbacks
	    current.result = callback(current.result, *args, **kw)
	  File "/home/ubuntu/venv/harold/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1184, in gotResult
	    _inlineCallbacks(r, g, deferred)
	--- <exception caught here> ---
	  File "/home/ubuntu/venv/harold/local/lib/python2.7/site-packages/twisted/internet/defer.py", line 1128, in _inlineCallbacks
	    result = g.send(result)
	  File "/home/ubuntu/src/harold/harold/plugins/deploy.py", line 767, in unhold
	    salon.unhold(irc)
	  File "/home/ubuntu/src/harold/harold/plugins/deploy.py", line 364, in unhold
	    self.update_topic(irc)
	  File "/home/ubuntu/src/harold/harold/plugins/deploy.py", line 302, in update_topic
	    irc.set_topic(self.channel, new_topic)
	exceptions.AttributeError: 'SlackPlugin' object has no attribute 'set_topic'
```