### PR TITLE
Fix send_annnouncement HTTP API bug

### DIFF
--- a/harold/plugins/deploy.py
+++ b/harold/plugins/deploy.py
@@ -237,7 +237,7 @@ class DeploySendAnnouncementListener(DeployListener):
 
     def _handle_request(self, request):
         message = request.args['message'][0]
-        self.monitor.announce(self.monitor.irc, 'harold', None, message)
+        self.monitor.announce(self.monitor.irc.bot, 'harold', None, message)
 
 
 class OngoingDeploy(object):


### PR DESCRIPTION
The existing code was not passing down the correct
Plugin object so we ended up with an unhandled
exception when trying to call the 'set_topic'
method.

Related commit where this was fixed for other HTTP API endpoints:
c7dfdde2f9d503f9d38ca10b29bfa7f1e5dd0840